### PR TITLE
typingWord добавлен в blacklist для redux-persist

### DIFF
--- a/src/redux/configureStore.ts
+++ b/src/redux/configureStore.ts
@@ -15,7 +15,7 @@ import gameReducer from './gameSlice';
 const persistConfig = {
   key: 'root',
   storage,
-  blacklist: ['requesting', 'info'],
+  blacklist: ['requesting', 'info', 'typingWord'],
 };
 
 const store = configureStore({


### PR DESCRIPTION
В момент обновления странице нажатием `Ctrl+R` иногда буква `R` печаталась в игру, затем ее приходилось стирать после обновления